### PR TITLE
Add typechecking to the project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Run typecheck
+        run: pnpm typecheck
+
       - name: Run build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit",
     "build": "zshy && cp README.md dist/README.md && cp LICENSE dist/LICENSE",
     "build:watch": "pnpx onchange@7.1.0 \"src/**\" -- pnpm run build",
     "pub": "npm run build && npm publish",

--- a/src/validators/field-to-zod.test.ts
+++ b/src/validators/field-to-zod.test.ts
@@ -108,7 +108,15 @@ describe('Field to Zod Conversion', () => {
     });
 
     it('should throw error for rollup (read-only)', () => {
-      const field: FieldSchema = { id: 'fld1', name: 'Rollup', type: 'rollup' };
+      const field: FieldSchema = {
+        id: 'fld1',
+        name: 'Rollup',
+        type: 'rollup',
+        options: {
+          result: { type: 'number' },
+          isValid: true,
+        },
+      };
       const schema = makeFieldWriteValidator(field);
       expect(schema.type).toBe('never');
       expect(() => schema.parse('any value')).toThrow();


### PR DESCRIPTION
- Add typecheck script to package.json to run tsc --noEmit
- Integrate typecheck into CI pipeline (runs in test job)
- Fix type error in rollup field test by adding required options property

Resolves #2